### PR TITLE
修改cloudflared应用的网络为host

### DIFF
--- a/apps/cloudflared/2026.1.2/docker-compose.yml
+++ b/apps/cloudflared/2026.1.2/docker-compose.yml
@@ -3,12 +3,7 @@ services:
     image: cloudflare/cloudflared:2026.1.2
     container_name: ${CONTAINER_NAME}
     restart: always
-    networks:
-      - 1panel-network
+    network_mode: host
     command: tunnel --no-autoupdate run --token ${CFD_TOKEN}
     labels:  
       createdBy: "Apps"
-
-networks:
-    1panel-network:
-        external: true

--- a/apps/cloudflared/latest/docker-compose.yml
+++ b/apps/cloudflared/latest/docker-compose.yml
@@ -4,12 +4,7 @@ services:
     pull_policy: always
     container_name: ${CONTAINER_NAME}
     restart: always
-    networks:
-      - 1panel-network
+    network_mode: host
     command: tunnel --no-autoupdate run --token ${CFD_TOKEN}
     labels:
       createdBy: "Apps"
-
-networks:
-  1panel-network:
-    external: true


### PR DESCRIPTION
修改cloudflared应用的网络为host，方便使用127.0.0.1或localhost映射本地主机服务
<img width="1632" height="326" alt="image" src="https://github.com/user-attachments/assets/73a6fc05-8427-4ce6-ac98-2796ba5873a7" />
